### PR TITLE
Yarn2: lataa vain depsut, ei dev-depsuja

### DIFF
--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -65,5 +65,10 @@ runs:
             yarn --frozen-lockfile --ignore-scripts
           fi
         else
-          yarn --immutable
+          if [ ${{ inputs.dependencies }} == "production" ]; then
+            yarn plugin import workspace-tools
+            yarn workspaces focus -A --production
+          else
+            yarn --immutable
+          fi
         fi


### PR DESCRIPTION
Yarn classicissa oli mahdollista kutsua `yarn install --production` joka latasi ja asensi ainoastaan ajon aikaiset depsut. Sama temppu yarn2:lla vaatii workspace-tools-plugaria. Tässä PR:ssä lisätään plugari lennosta (jos oli jo asennettuna, niin ei haittaa) ja haetaan vain depsut, jos yarn-actionin parametreissä on `dependencies: production`