### PR TITLE
chore: update actions/setup-node to v3, migrate set-output usage

### DIFF
--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -23,11 +23,11 @@ runs:
       shell: bash
       run: |
         [ ! -f "./.nvmrc" ] && echo "ERROR: File ./.nvmrc not found, exiting..." && exit 1
-        echo "::set-output name=nvmrc::$(cat .nvmrc)"
+        echo "name=nvmrc::$(cat .nvmrc)" >> $GITHUB_OUTPUT
         echo "NVMRC: $(cat .nvmrc)"
 
     - name: Set up node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ steps.nvmrc.outputs.nvmrc }}
         registry-url: 'https://npm.pkg.github.com/'
@@ -37,7 +37,7 @@ runs:
     - name: Get yarn version
       id: yarn-version
       shell: bash
-      run: echo "::set-output name=version::$(yarn --version | cut -d . -f 1)"
+      run: echo "name=version::$(yarn --version | cut -d . -f 1)" >> $GITHUB_OUTPUT
 
     - name: "Set Yarn cache with dependencies: '${{ inputs.dependencies }}'"
       uses: actions/cache@v3


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/