### PR TITLE
Workaround for corepack support in setup-node

### DIFF
--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -30,13 +30,18 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ steps.nvmrc.outputs.nvmrc }}
-        registry-url: 'https://npm.pkg.github.com/'
-        scope: '@yleisradio'
-        cache: yarn
 
     - name: Enable corepack
       shell: bash
       run: corepack enable
+
+    - name: Set up yarn
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ steps.nvmrc.outputs.nvmrc }}
+        registry-url: 'https://npm.pkg.github.com/'
+        scope: '@yleisradio'
+        cache: yarn
 
     - name: Get yarn version
       id: yarn-version


### PR DESCRIPTION
`setup-node` action ei pysty asentamaan yarnia jos corepack on käytössä. Ongelman voi kiertää asettamalla `SKIP_YARN_COREPACK_CHECK=1`, mutta se taas hajoittaa `setup-node`n välimuistin käytön. 

Väliaikainen korjaus kunnes `setup-node` on kunnossa on esitetty [täällä](https://github.com/actions/setup-node/issues/899#issuecomment-1828798029). 